### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -1,0 +1,35 @@
+import jax.numpy as jnp
+from jax import random
+from jaxbo import acquisitions
+
+
+def test_ei_basic():
+    mean = jnp.array([0.5])
+    std = jnp.array([1.0])
+    best = 0.0
+    # EI returns negative improvement
+    val = acquisitions.EI(mean, std, best)
+    assert val < 0
+
+
+def test_eic_constraints():
+    mean = jnp.array([[0.5], [1.0]])
+    std = jnp.array([[1.0], [1.0]])
+    best = 0.0
+    val = acquisitions.EIC(mean, std, best)
+    assert val < 0
+
+
+def test_lcb_basic():
+    mean = jnp.array([1.0])
+    std = jnp.array([0.5])
+    val = acquisitions.LCB(mean, std, kappa=2.0)
+    # LCB = mean - kappa*std
+    assert jnp.isclose(val, mean - 2.0 * std)
+
+
+def test_us():
+    std = jnp.array([0.5])
+    val = acquisitions.US(std)
+    assert jnp.isclose(val, -0.5)
+

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,0 +1,20 @@
+import jax.numpy as jnp
+from jaxbo import kernels
+
+
+def test_pairwise_diff_squared():
+    x1 = jnp.array([[0.0, 0.0], [1.0, 1.0]])
+    x2 = jnp.array([[0.0, 0.0]])
+    length = jnp.array([1.0, 1.0])
+    d2 = kernels._pairwise_diff_squared(x1, x2, length)
+    assert d2.shape == (2, 1)
+    assert jnp.allclose(d2, jnp.array([[0.0], [2.0]]))
+
+
+def test_rbf_kernel():
+    x = jnp.array([[0.0], [1.0]])
+    params = jnp.array([1.0, 1.0])
+    K = kernels.RBF(x, x, params)
+    assert K.shape == (2, 2)
+    assert jnp.isclose(K[0, 0], 1.0)
+

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,25 @@
+import numpy as np
+from jaxbo.optimizers import minimize_lbfgs, minimize_lbfgs_grad
+
+
+def quad(x):
+    return np.sum((x - 3.0) ** 2)
+
+
+def quad_grad(x):
+    loss = quad(x)
+    grad = 2 * (x - 3.0)
+    return loss, grad
+
+
+def test_minimize_lbfgs():
+    x_opt, f_opt = minimize_lbfgs(quad, np.array([0.0]))
+    assert np.allclose(x_opt, 3.0, atol=1e-3)
+    assert f_opt < 1e-6
+
+
+def test_minimize_lbfgs_grad():
+    x_opt, f_opt = minimize_lbfgs_grad(quad_grad, np.array([0.0]))
+    assert np.allclose(x_opt, 3.0, atol=1e-3)
+    assert f_opt < 1e-6
+

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,0 +1,22 @@
+import jax.numpy as jnp
+from jax import random
+from jaxbo.input_priors import uniform_prior, gaussian_prior
+
+
+def test_uniform_prior_sample_pdf():
+    prior = uniform_prior(jnp.array([0.0, 0.0]), jnp.array([1.0, 1.0]))
+    key = random.PRNGKey(0)
+    samples = prior.sample(key, 5)
+    assert samples.shape == (5, 2)
+    pdf_vals = prior.pdf(samples)
+    assert jnp.all(pdf_vals > 0)
+
+
+def test_gaussian_prior_sample_pdf():
+    prior = gaussian_prior(jnp.zeros(2), jnp.eye(2))
+    key = random.PRNGKey(1)
+    samples = prior.sample(key, 3)
+    assert samples.shape == (3, 2)
+    pdf_vals = prior.pdf(samples)
+    assert jnp.all(pdf_vals > 0)
+

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -1,0 +1,17 @@
+import jax.numpy as jnp
+from jaxbo.test_functions import StepFunction, ForresterFunction
+
+
+def test_step_function():
+    f = StepFunction()
+    assert f.evaluate(jnp.array([-0.1])) == 0
+    assert f.evaluate(jnp.array([0.1])) == 1
+
+
+def test_forrester_high_low():
+    f = ForresterFunction()
+    x = jnp.array([0.2])
+    high = f.evaluate_high(x)
+    low = f.evaluate_low(x)
+    assert high != low
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import jax.numpy as jnp
+from jaxbo import utils
+
+
+def test_standardize():
+    X = jnp.array([[1.0], [2.0]])
+    y = jnp.array([1.0, 3.0])
+    batch, norm = utils.standardize(X, y)
+    assert jnp.allclose(batch['X'].mean(), 0.0)
+    assert jnp.allclose(batch['y'].mean(), 0.0)
+    assert 'mu_X' in norm and 'sigma_X' in norm
+
+
+def test_compute_w_gmm():
+    x = jnp.array([0.5, 0.5])
+    bounds = {'lb': jnp.zeros(2), 'ub': jnp.ones(2)}
+    weights = jnp.array([1.0])
+    means = jnp.array([[0.5, 0.5]])
+    covs = jnp.eye(2).reshape(1,2,2)
+    val = utils.compute_w_gmm(x, bounds=bounds, gmm_vars=(weights, means, covs))
+    assert val > 0
+


### PR DESCRIPTION
## Summary
- add tests covering acquisitions
- add tests covering kernels and priors
- add tests for optimizers and utilities
- add tests for some provided functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440c0b9b3c832dbe17b996d961a436