### PR TITLE
fix: replace pyDOE with scipy.stats.qmc.LatinHypercube

### DIFF
--- a/examples/constrained_bo_ManifoldGP_MultiOutputs.py
+++ b/examples/constrained_bo_ManifoldGP_MultiOutputs.py
@@ -13,7 +13,7 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 from scipy.optimize import minimize
-from pyDOE import lhs
+from scipy.stats import qmc
 import matplotlib.pyplot as plt
 plt.close('all')
 from matplotlib import rc
@@ -156,12 +156,13 @@ gp_model = ManifoldGP_MultiOutputs(options, layers)
 bounds = {'lb': lb, 'ub': ub}
 
 # Initial training data for objective
-X_f = lb + (ub-lb)*lhs(dim, N_f)
+sampler = qmc.LatinHypercube(d=dim, seed=1234)
+X_f = lb + (ub-lb)*sampler.random(N_f)
 y_f = vmap(f)(X_f)
 y_f = y_f + noise_f*y_f_star.std(0)*onp.random.normal(0, 1, size=y_f.shape)
 
 # Initial training data for constraints
-X_c = lb + (ub-lb)*lhs(dim, N_c)
+X_c = lb + (ub-lb)*sampler.random(N_c)
 y1_c = vmap(constraint1)(X_c)
 y1_c = y1_c + noise_c*y1_c_star.std(0)*onp.random.normal(0, 1, size=y1_c.shape)
 

--- a/examples/manifold_multioutput_gp.py
+++ b/examples/manifold_multioutput_gp.py
@@ -12,7 +12,7 @@ from jax import random, vmap
 import jax
 jax.config.update("jax_enable_x64", True)
 
-from pyDOE import lhs
+from scipy.stats import qmc
 import matplotlib.pyplot as plt
 plt.close('all')
 import matplotlib
@@ -89,12 +89,13 @@ gp_model = ManifoldGP_MultiOutputs(options, layers)
 bounds = {'lb': lb, 'ub': ub}
 
 # Initial training data for objective
-X_f = lb + (ub-lb)*lhs(dim, N_f)
+sampler = qmc.LatinHypercube(d=dim, seed=1234)
+X_f = lb + (ub-lb)*sampler.random(N_f)
 y_f = vmap(f)(X_f)
 y_f = y_f + noise_f*y_f_star.std(0)*onp.random.normal(0, 1, size=y_f.shape)
 
 # Initial training data for constraints
-X_c = lb + (ub-lb)*lhs(dim, N_c)
+X_c = lb + (ub-lb)*sampler.random(N_c)
 y1_c = vmap(constraint1)(X_c)
 y1_c = y1_c + noise_c*y1_c_star.std(0)*onp.random.normal(0, 1, size=y1_c.shape)
 

--- a/jaxbo/models/base_gpmodel.py
+++ b/jaxbo/models/base_gpmodel.py
@@ -7,7 +7,7 @@ import numpy as onp
 from jax import jit, random, vjp, vmap
 from jax.random import split
 from jax.scipy.linalg import solve_triangular
-from pyDOE import lhs
+from scipy.stats import qmc
 from sklearn import mixture
 
 import jaxbo.acquisitions as acquisitions
@@ -180,13 +180,15 @@ class GPmodel(ABC):
 
         # Sample data uniformly over the full input space
         onp.random.seed(rng_key[0])
-        X = lb + (ub - lb) * lhs(dim, N_samples)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        X = lb + (ub - lb) * sampler.random(N_samples)
         y = self.predict(X, **kwargs)[0]
 
         # Sample inputs according to the prior distribution
         rng_key = split(rng_key)[0]
         onp.random.seed(rng_key[0])
-        X_samples = lb + (ub - lb) * lhs(dim, N_samples)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        X_samples = lb + (ub - lb) * sampler.random(N_samples)
         y_samples = self.predict(X_samples, **kwargs)[0]
 
         # Estimate output densities from both prior and uniform samples
@@ -385,7 +387,8 @@ class GPmodel(ABC):
         # Generate initial points using Latin Hypercube Sampling
         rng_key = kwargs["rng_key"]
         onp.random.seed(rng_key[0])  # Deterministic initialization
-        initial_points = lb + (ub - lb) * lhs(dim, num_restarts)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        initial_points = lb + (ub - lb) * sampler.random(num_restarts)
 
         # Format bounds for SciPy optimizer
         dom_bounds = tuple(map(tuple, np.vstack((lb, ub)).T))

--- a/jaxbo/models/deep_multifidelity_gp_multioutputs.py
+++ b/jaxbo/models/deep_multifidelity_gp_multioutputs.py
@@ -5,7 +5,7 @@ import numpy as onp
 from jax import jit, random, vjp
 from jax.flatten_util import ravel_pytree
 from jax.scipy.linalg import cholesky, solve_triangular
-from pyDOE import lhs
+from scipy.stats import qmc
 
 import jaxbo.acquisitions as acquisitions
 import jaxbo.initializers as initializers
@@ -253,7 +253,8 @@ class DeepMultifidelityGP_MultiOutputs(GPmodel):
         dim = lb.shape[0]
 
         onp.random.seed(rng_key[0])
-        x0 = lb + (ub - lb) * lhs(dim, num_restarts)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        x0 = lb + (ub - lb) * sampler.random(num_restarts)
         # print("x0 for bfgs", x0)
         dom_bounds = tuple(map(tuple, np.vstack((lb, ub)).T))
         for i in range(num_restarts):

--- a/jaxbo/models/manifold_gp_multioutputs.py
+++ b/jaxbo/models/manifold_gp_multioutputs.py
@@ -9,7 +9,7 @@ import jaxbo.acquisitions as acquisitions
 import jaxbo.initializers as initializers
 import jaxbo.utils as utils
 from jaxbo.optimizers import minimize_lbfgs
-from pyDOE import lhs
+from scipy.stats import qmc
 
 from jaxbo.models.base_gpmodel import GPmodel
 
@@ -203,7 +203,8 @@ class ManifoldGP_MultiOutputs(GPmodel):
         dim = lb.shape[0]
 
         onp.random.seed(rng_key[0])
-        x0 = lb + (ub - lb) * lhs(dim, num_restarts)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        x0 = lb + (ub - lb) * sampler.random(num_restarts)
         # print("x0 for bfgs", x0)
         dom_bounds = tuple(map(tuple, np.vstack((lb, ub)).T))
         for i in range(num_restarts):

--- a/jaxbo/models/multiple_independent_heterogeneous_mfgp.py
+++ b/jaxbo/models/multiple_independent_heterogeneous_mfgp.py
@@ -11,7 +11,7 @@ import jaxbo.initializers as initializers
 import jaxbo.utils as utils
 from jaxbo.optimizers import minimize_lbfgs
 from sklearn import mixture
-from pyDOE import lhs
+from scipy.stats import qmc
 
 from jax.scipy.stats import norm
 from jaxbo.models.base_gpmodel import GPmodel
@@ -231,7 +231,8 @@ class MultipleIndependentHeterogeneousMFGP(GPmodel):
         dim = lb.shape[0]
 
         onp.random.seed(rng_key[0])
-        x0 = lb + (ub - lb) * lhs(dim, num_restarts)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        x0 = lb + (ub - lb) * sampler.random(num_restarts)
         # print("x0 for bfgs", x0)
         dom_bounds = tuple(map(tuple, np.vstack((lb, ub)).T))
         for i in range(num_restarts):
@@ -253,11 +254,10 @@ class MultipleIndependentHeterogeneousMFGP(GPmodel):
         rng_key = kwargs["rng_key"]
         dim = lb.shape[0]
         # Sample data across the entire domain
-        X = lb + (ub - lb) * lhs(dim, N_samples)
-
         # set the seed for sampling X
         onp.random.seed(rng_key[0])
-        X = lb + (ub - lb) * lhs(dim, N_samples)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        X = lb + (ub - lb) * sampler.random(N_samples)
 
         # We only keep the first row that correspond to the objective prediction and same for y_samples
         y = self.predict_all(X, **kwargs)[0][0, :]
@@ -278,7 +278,8 @@ class MultipleIndependentHeterogeneousMFGP(GPmodel):
         rng_key = random.split(rng_key)[0]
         onp.random.seed(rng_key[0])
 
-        X_samples = lb + (ub - lb) * lhs(dim, N_samples)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        X_samples = lb + (ub - lb) * sampler.random(N_samples)
         y_samples = self.predict_all(X_samples, **kwargs)[0][0, :]
 
         # Compute p_x and p_y from samples across the entire domain

--- a/jaxbo/models/multiple_independent_mfgp.py
+++ b/jaxbo/models/multiple_independent_mfgp.py
@@ -9,7 +9,7 @@ import jaxbo.initializers as initializers
 import jaxbo.utils as utils
 from jaxbo.optimizers import minimize_lbfgs
 from sklearn import mixture
-from pyDOE import lhs
+from scipy.stats import qmc
 
 from jax.scipy.stats import norm
 from jaxbo.models.base_gpmodel import GPmodel
@@ -208,7 +208,8 @@ class MultipleIndependentMFGP(GPmodel):
         dim = lb.shape[0]
 
         onp.random.seed(rng_key[0])
-        x0 = lb + (ub - lb) * lhs(dim, num_restarts)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        x0 = lb + (ub - lb) * sampler.random(num_restarts)
         # print("x0 for bfgs", x0)
         dom_bounds = tuple(map(tuple, np.vstack((lb, ub)).T))
         for i in range(num_restarts):
@@ -230,11 +231,10 @@ class MultipleIndependentMFGP(GPmodel):
         rng_key = kwargs["rng_key"]
         dim = lb.shape[0]
         # Sample data across the entire domain
-        X = lb + (ub - lb) * lhs(dim, N_samples)
-
         # set the seed for sampling X
         onp.random.seed(rng_key[0])
-        X = lb + (ub - lb) * lhs(dim, N_samples)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        X = lb + (ub - lb) * sampler.random(N_samples)
 
         # We only keep the first row that correspond to the objective prediction and same for y_samples
         y = self.predict_all(X, **kwargs)[0][0, :]
@@ -255,7 +255,8 @@ class MultipleIndependentMFGP(GPmodel):
         rng_key = random.split(rng_key)[0]
         onp.random.seed(rng_key[0])
 
-        X_samples = lb + (ub - lb) * lhs(dim, N_samples)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        X_samples = lb + (ub - lb) * sampler.random(N_samples)
         y_samples = self.predict_all(X_samples, **kwargs)[0][0, :]
 
         # Compute p_x and p_y from samples across the entire domain

--- a/jaxbo/models/multiple_independent_output_gp_model.py
+++ b/jaxbo/models/multiple_independent_output_gp_model.py
@@ -3,7 +3,7 @@ import jax.numpy as np
 from jax import jit, vjp, random
 from jax.scipy.linalg import cholesky, solve_triangular
 from functools import partial
-from pyDOE import lhs
+from scipy.stats import qmc
 from typing import List, Dict, Tuple, Any
 
 import jaxbo.acquisitions as acquisitions
@@ -170,7 +170,8 @@ class MultipleIndependentOutputsGP(GPmodel):
         dim = lb.shape[0]
         rng_key = kwargs["rng_key"]
         onp.random.seed(rng_key[0])
-        x0 = lb + (ub - lb) * lhs(dim, num_restarts)
+        sampler = qmc.LatinHypercube(d=dim, seed=int(rng_key[0]))
+        x0 = lb + (ub - lb) * sampler.random(num_restarts)
         dom_bounds = tuple(map(tuple, np.vstack((lb, ub)).T))
 
         loc, acq = [], []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "jaxlib",
   "scikit-learn",
   "KDEpy",
-  "pyDOE",
   "numpyro"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ keywords = ["jax", "bayesian optimization", "machine learning", "optimization"]
 
 dependencies = [
   "numpy",
-  "scipy",
+  # scipy.stats.qmc (the pyDOE replacement) first shipped in scipy 1.7.0
+  "scipy>=1.7",
   "jax",
   "jaxlib",
   "scikit-learn",


### PR DESCRIPTION
## What changed

Replaces the dead pyDOE dependency with scipy.stats.qmc.LatinHypercube (scipy is already a dependency; no new deps added, jax pin untouched, that is slice 1c).

- 6 model files under `jaxbo/models/`: `base_gpmodel.py`, `deep_multifidelity_gp_multioutputs.py`, `manifold_gp_multioutputs.py`, `multiple_independent_heterogeneous_mfgp.py`, `multiple_independent_mfgp.py`, `multiple_independent_output_gp_model.py`. Each `lhs(dim, n)` call becomes `qmc.LatinHypercube(d=dim, seed=int(rng_key[0])).random(n)`, preserving the `(n_samples, dim)` return shape and unit-hypercube semantics and threading the existing `rng_key` through as the explicit seed. The neighboring `onp.random.seed(rng_key[0])` lines are kept untouched: they also seed downstream `onp.random.choice` resampling in `fit_gmm`.
- In the two `fit_gmm` variants (`multiple_independent_mfgp.py`, `multiple_independent_heterogeneous_mfgp.py`) a dead pre-seed `lhs` draw whose result was immediately overwritten by the seeded draw two lines later was dropped; final values are unchanged.
- 2 example scripts (`examples/constrained_bo_ManifoldGP_MultiOutputs.py`, `examples/manifold_multioutput_gp.py`): one `qmc.LatinHypercube(d=dim, seed=1234)` sampler (matching the scripts' existing `onp.random.seed(1234)`), drawn twice for objective and constraint data.
- `pyproject.toml`: `pyDOE` removed from dependencies.

Notebooks still mentioning pyDOE were intentionally left out of scope for this slice.

## Verification

Clean Python 3.12.6 venv, `pip install "jax<0.10" "jaxlib<0.10" -e .` (the jax pin lives in the venv only, since the jax 0.10 `clip` breakage is slice 1c). Resulting venv: jax 0.9.2, scipy 1.18.0, numpy 2.5.1.

```
> python -m pip show pyDOE
WARNING: Package(s) not found: pyDOE

> python -c "import jax, scipy, numpy; ...; import jaxbo; import jaxbo.models; ..."
jax 0.9.2 | scipy 1.18.0 | numpy 2.5.1
import jaxbo: OK
LHS shape (n_samples, dim), unit hypercube, deterministic per seed: OK

> python -m pytest tests
14 passed, 1 warning in 10.62s
```

`tox -e py312` (installs unpinned jax per pyproject): 13 passed, 1 failed. The one failure is `tests/test_acquisitions.py::test_eic_constraints` with `TypeError: clip() got an unexpected keyword argument 'a_min'`, the known jax>=0.10 breakage owned by slice 1c; nothing pyDOE-related. `tox -e lint` was already failing on main before this change (black double-blank-line plus repo-wide ruff findings); ruff finding counts on `jaxbo/` are byte-identical between main and this branch.

Closes #23
