### PR TITLE
probe: docs-only gating check (throwaway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ All modifications and release notes are documented in the [CHANGELOG](CHANGELOG.
 ---
 ## License ##
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
+CI is described in .github/workflows/ci.yml.


### PR DESCRIPTION
Throwaway probe for #48: verifies a docs-only diff runs just the docs lint path plus ci-ok, with python jobs skipped. Will be closed after the run is recorded.