### PR TITLE
feat: acquisitions.score_candidates, vmap-batched candidate scoring (2c)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,7 +80,7 @@ shares.
 |---|---|
 | `bench_train.py` | `train_warm_instance`: one GP instance, first call untimed, re-trained in the timed rounds (jit cache hot), n = 32 / 128 / 512, `num_restarts=3`. `train_fresh_instance`: a new `GP(...)` constructed inside every timed round and trained once (n=128), the consumer pattern; every round pays the instance-keyed recompilation |
 | `bench_predict.py` | one batched `GP.predict` over 256 4D points after one train (n=128) |
-| `bench_acquisition.py` | `ei_consumer_path`: per candidate, a `(1, 4)` `gp.predict` then `acquisitions.EI(mu, std, best)` then a host `float()`, over 256 candidates (the exact shelter-pulse loop). `ei_fused_acquisition`: the same loop through the fused `gp.acquisition` graph, kept for comparison |
+| `bench_acquisition.py` | `ei_consumer_path`: per candidate, a `(1, 4)` `gp.predict` then `acquisitions.EI(mu, std, best)` then a host `float()`, over 256 candidates (the exact shelter-pulse loop). `ei_fused_acquisition`: the same loop through the fused `gp.acquisition` graph, kept for comparison. `ei_score_candidates`: all 256 candidates in one batched `acquisitions.score_candidates` call, the loop's replacement (issue #28) |
 
 Every bench times its first call separately and reports it as
 `first_call_latency_s` in `extra_info`. First-call latency conflates trace +

--- a/benchmarks/bench_acquisition.py
+++ b/benchmarks/bench_acquisition.py
@@ -10,6 +10,11 @@ transfer. This is the loop a future batched score_candidates replaces.
 A secondary case keeps the fused gp.acquisition per-candidate variant
 for comparison (single fused predict + EI graph per candidate).
 
+The batched case scores all 256 candidates in one
+acquisitions.score_candidates call (issue #28), the replacement for the
+consumer loop above; its delta against bench_ei_consumer_path_256 is the
+number that gates the claim.
+
 First-call latency (trace + compile + execute) is timed separately and
 reported as first_call_latency_s in extra_info.
 """
@@ -73,3 +78,27 @@ def bench_ei_fused_acquisition_256(benchmark, trained_128):
         return jax.block_until_ready(vals)
 
     benchmark(ei_loop)
+
+
+def bench_ei_score_candidates_256(benchmark, trained_128):
+    gp, kwargs = trained_128
+    # Same inputs as the consumer-path bench: params/batch/bounds only,
+    # same seed, same Dirichlet candidates.
+    pk = {k: kwargs[k] for k in ("params", "batch", "bounds")}
+    best = float(kwargs["batch"]["y"].min())
+    rng = onp.random.default_rng(SEED + 1)
+    X_cand = jnp.asarray(rng.dirichlet(onp.ones(DIM), size=N_CANDIDATES))
+
+    def ei_batched():
+        return jax.block_until_ready(
+            acquisitions.score_candidates(gp, X_cand, **pk, best=best)
+        )
+
+    t0 = time.perf_counter()
+    ei_batched()
+    first_s = time.perf_counter() - t0
+
+    benchmark.extra_info["candidates"] = N_CANDIDATES
+    benchmark.extra_info["first_call_latency_s"] = round(first_s, 4)
+
+    benchmark(ei_batched)

--- a/benchmarks/results/2026-07-29-score-candidates.md
+++ b/benchmarks/results/2026-07-29-score-candidates.md
@@ -1,0 +1,44 @@
+# score_candidates delta: batched EI scoring vs the consumer loop, 2026-07-29
+
+Delta record for `acquisitions.score_candidates` (issue #28, slice 2c), per
+the AGENTS.md rule that no perf change lands without before/after numbers
+from this suite. Before and after are measured in the SAME environment and
+session (`pytest benchmarks/bench_acquisition.py`, 3 runs, same seeds and
+fixtures as the baseline suite); the 2026-07-28 baseline file is a
+historical record and is not edited.
+
+## Environment
+
+Same machine as the baseline (11th Gen Intel Core i7-1185G7, 8 logical
+CPUs, Windows 10 Pro build 19045, CPU-only jax). Python 3.12.6, jax /
+jaxlib 0.10.2 (the baseline recorded jax 0.9.2; #52 moved the pin), numpy
+2.5.1, scipy 1.18.0, pytest-benchmark 5.2.3.
+
+## Numbers
+
+Medians per run in ms; the headline number is the median of the three run
+medians. All cases score the same 256 Dirichlet candidates against the
+same trained GP (n=128, 4D).
+
+| Case | Run 1 | Run 2 | Run 3 | Median | Per candidate |
+|---|---|---|---|---|---|
+| EI consumer path, 256 candidates (before) | 230.3 | 224.4 | 177.5 | 224.4 | 0.877 ms |
+| EI fused `gp.acquisition` loop (reference) | 150.2 | 131.7 | 129.7 | 131.7 | 0.514 ms |
+| `score_candidates`, 256 candidates (after) | 2.95 | 2.91 | 2.67 | 2.91 | 0.011 ms |
+
+- **Delta: 224.4 ms to 2.91 ms, a 77x speedup (98.7 percent reduction).**
+  The consumer-path noise band in `2026-07-28-baseline.md` is 9.9 percent;
+  this clears it by two orders of magnitude.
+- First-call latency (trace + compile + execute) of the batched case: 0.67
+  to 0.90 s across the runs, vs 0.43 to 0.55 s for the loop's first
+  candidate; the win is not smuggled into compile time.
+- The 2026-07-28 baseline recorded the consumer path at 137.0 ms on jax
+  0.9.2. These runs sat on a busier machine and a newer jax (both loop and
+  batched case move together), which is why before AND after were
+  re-measured here instead of comparing against the stored baseline
+  number.
+
+Raw pytest-benchmark JSON for the three runs was captured locally
+(`bench-2c-final-{1,2,3}.json`); the medians above are reproducible with
+`pytest benchmarks/bench_acquisition.py --benchmark-json=...` on any
+machine, subject to its own noise band.

--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -247,14 +247,10 @@ def score_candidates(model, X_cand, *, params, batch, bounds, acq_fn=EI, **acq_k
     """
     X_cand = np.asarray(X_cand)
     if X_cand.ndim != 2:
-        raise ValueError(
-            f"X_cand must have shape (N, D); got shape {X_cand.shape}"
-        )
+        raise ValueError(f"X_cand must have shape (N, D); got shape {X_cand.shape}")
 
     def score_one(x):
-        mean, std = model.predict(
-            x[None, :], params=params, batch=batch, bounds=bounds
-        )
+        mean, std = model.predict(x[None, :], params=params, batch=batch, bounds=bounds)
         return acq_fn(mean, std, **acq_kwargs)
 
     return np.reshape(vmap(score_one)(X_cand), (-1,))

--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -241,16 +241,37 @@ def score_candidates(model, X_cand, *, params, batch, bounds, acq_fn=EI, **acq_k
     **acq_kwargs: Extra arguments forwarded to ``acq_fn``, e.g.
         ``best=float(np.min(batch['y']))`` for EI (best observed target in
         the same normalized space as ``batch['y']``), or ``kappa`` for LCB.
+        They are shared by ALL candidates, not mapped: per-candidate
+        arguments (e.g. the LW_* ``weights``) are rejected; use vmap
+        directly for those.
 
     Returns:
     np.ndarray: Acquisition scores, shape (N,).
+
+    Raises:
+    ValueError: If ``X_cand`` is not (N, D) with D matching the training
+        batch (a (N, 1) array against a 4D model would otherwise broadcast
+        silently inside predict), or if ``acq_fn`` returns more than one
+        score per candidate (per-candidate acq_kwargs).
     """
     X_cand = np.asarray(X_cand)
-    if X_cand.ndim != 2:
-        raise ValueError(f"X_cand must have shape (N, D); got shape {X_cand.shape}")
+    dim = batch["X"].shape[1]
+    if X_cand.ndim != 2 or X_cand.shape[1] != dim:
+        raise ValueError(
+            f"X_cand must have shape (N, D) with D={dim} matching the training "
+            f"batch; got shape {X_cand.shape}"
+        )
 
     def score_one(x):
         mean, std = model.predict(x[None, :], params=params, batch=batch, bounds=bounds)
         return acq_fn(mean, std, **acq_kwargs)
 
-    return np.reshape(vmap(score_one)(X_cand), (-1,))
+    scores = vmap(score_one)(X_cand)
+    if scores.size != X_cand.shape[0]:
+        raise ValueError(
+            f"acq_fn must return one score per candidate; got batched shape "
+            f"{scores.shape} for {X_cand.shape[0]} candidates. Per-candidate "
+            "acq_kwargs (e.g. LW_* weights) are not supported here; use vmap "
+            "directly instead."
+        )
+    return np.reshape(scores, (-1,))

--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -1,8 +1,9 @@
 import jax.numpy as np
-from jax import jit
+from jax import jit, vmap
 from jax.scipy.stats import norm
 
-# Caution: all functions are designed for single point evaluation (use vmap to vectorize)
+# Caution: all functions below are designed for single point evaluation; use
+# score_candidates (or vmap directly) to score a batch of candidates.
 # See derivation in:
 # https://people.orie.cornell.edu/pfrazier/Presentations/2011.11.INFORMS.Tutorial.pdf
 
@@ -200,3 +201,60 @@ def LW_CLSF(
         np.log(std + 1e-8) + np.log(weights + 1e-8)
     )
     return acq[0]
+
+
+def score_candidates(model, X_cand, *, params, batch, bounds, acq_fn=EI, **acq_kwargs):
+    """
+    Scores a batch of candidate points in one vmapped pass.
+
+    Replaces the per-candidate Python loop over ``model.predict`` plus a
+    single-point acquisition (the shelter-pulse pattern: reshape each
+    candidate to (1, D), predict, score, ``float()``), which pays two jit
+    dispatches and a device to host sync per candidate. Here the whole
+    candidate set is scored in a single batched call; the Cholesky factor
+    of the training covariance does not depend on the candidate, so vmap
+    computes it once, not N times.
+
+    Shape conventions:
+    - X_cand has shape (N, D) and lives in the RAW domain. Like
+      ``model.predict``, each candidate is normalized internally against
+      ``bounds``; do NOT pre-normalize it. ``batch``, by contrast, must be
+      the ALREADY NORMALIZED training batch, exactly as passed to
+      ``model.train`` (mixing these up fails silently, see jaxbo.gp.GP).
+    - Each candidate is scored as a single (1, D) point, so ``acq_fn``
+      sees the single-point shapes used throughout this module: ``mean``
+      of shape (1, 1), ``std`` of shape (1,), the ``[0]`` indexing
+      convention.
+    - Returns an (N,) array of scores, one per candidate, in candidate
+      order. Lower is better for every acquisition in this module (EI is
+      returned negated), so the next point is ``X_cand[np.argmin(scores)]``.
+
+    Parameters:
+    model: Trained GP model exposing ``predict(X_star, params=, batch=, bounds=)``,
+        e.g. ``jaxbo.gp.GP``.
+    X_cand (np.ndarray): Candidate points, shape (N, D), raw domain.
+    params (np.ndarray): Trained hyperparameters, as returned by ``model.train``.
+    batch (dict): The already normalized training batch ({'X', 'y'}) used to train.
+    bounds (dict): {'lb', 'ub'} domain bounds predict normalizes against.
+    acq_fn (callable): Single-point acquisition taking (mean, std, **acq_kwargs).
+        Defaults to EI.
+    **acq_kwargs: Extra arguments forwarded to ``acq_fn``, e.g.
+        ``best=float(np.min(batch['y']))`` for EI (best observed target in
+        the same normalized space as ``batch['y']``), or ``kappa`` for LCB.
+
+    Returns:
+    np.ndarray: Acquisition scores, shape (N,).
+    """
+    X_cand = np.asarray(X_cand)
+    if X_cand.ndim != 2:
+        raise ValueError(
+            f"X_cand must have shape (N, D); got shape {X_cand.shape}"
+        )
+
+    def score_one(x):
+        mean, std = model.predict(
+            x[None, :], params=params, batch=batch, bounds=bounds
+        )
+        return acq_fn(mean, std, **acq_kwargs)
+
+    return np.reshape(vmap(score_one)(X_cand), (-1,))

--- a/tests/test_score_candidates.py
+++ b/tests/test_score_candidates.py
@@ -1,0 +1,104 @@
+"""Tests for acquisitions.score_candidates (issue #28, slice 2c).
+
+Parity is checked against the exact serial consumer loop from shelter-pulse
+jaxbo_optimizer.py: per candidate, reshape to (1, D), gp.predict with
+params/batch/bounds, acquisitions.EI, host float().
+"""
+
+import jax.numpy as jnp
+import numpy as onp
+import pytest
+from jax import random
+
+from jaxbo import acquisitions
+from jaxbo.gp import GP
+from jaxbo.utils import normalize
+
+N_CAND = 32
+
+
+def _trained_gp(dim, n=24, seed=0):
+    """Small trained GP on [0, 1]^dim with the normalized-batch contract."""
+    rng = onp.random.default_rng(seed)
+    X = jnp.asarray(rng.uniform(size=(n, dim)))
+    y = jnp.sin(3.0 * X[:, 0]) + 0.1 * jnp.asarray(rng.standard_normal(n))
+    bounds = {"lb": jnp.zeros(dim), "ub": jnp.ones(dim)}
+    batch, _ = normalize(X, y[:, None], bounds)
+    gp = GP({"kernel": "Matern52", "criterion": "EI", "input_prior": None})
+    params = gp.train(batch, random.PRNGKey(seed), num_restarts=2)
+    X_cand = jnp.asarray(rng.uniform(size=(N_CAND, dim)))
+    return gp, params, batch, bounds, X_cand
+
+
+@pytest.fixture(scope="module")
+def gp1d():
+    return _trained_gp(1)
+
+
+@pytest.fixture(scope="module")
+def gp4d():
+    return _trained_gp(4)
+
+
+def _serial_ei_loop(gp, params, batch, bounds, X_cand, best):
+    """The verbatim shelter-pulse consumer pattern."""
+    out = []
+    for i in range(X_cand.shape[0]):
+        c = jnp.asarray(X_cand[i]).reshape(1, -1)
+        mu, std = gp.predict(c, params=params, batch=batch, bounds=bounds)
+        out.append(float(acquisitions.EI(mu, std, best)[0]))
+    return onp.asarray(out)
+
+
+@pytest.mark.parametrize("problem", ["gp1d", "gp4d"])
+def test_shape_and_parity_with_serial_loop(problem, request):
+    gp, params, batch, bounds, X_cand = request.getfixturevalue(problem)
+    best = float(jnp.min(batch["y"]))
+
+    scores = acquisitions.score_candidates(
+        gp, X_cand, params=params, batch=batch, bounds=bounds, best=best
+    )
+
+    assert scores.shape == (N_CAND,)
+    assert bool(jnp.all(jnp.isfinite(scores)))
+
+    serial = _serial_ei_loop(gp, params, batch, bounds, X_cand, best)
+    # float32: batched XLA fusion reorders reductions vs the serial graph,
+    # so bit-exactness is not expected; 1e-4 still catches any real bug.
+    onp.testing.assert_allclose(onp.asarray(scores), serial, rtol=1e-4, atol=1e-6)
+    # Same argmin: the point the consumer would pick next is unchanged.
+    assert int(jnp.argmin(scores)) == int(onp.argmin(serial))
+
+
+def test_acq_fn_and_kwargs_forwarding(gp1d):
+    """acq_fn is pluggable and extra kwargs reach it (LCB with kappa)."""
+    gp, params, batch, bounds, X_cand = gp1d
+
+    scores = acquisitions.score_candidates(
+        gp,
+        X_cand,
+        params=params,
+        batch=batch,
+        bounds=bounds,
+        acq_fn=acquisitions.LCB,
+        kappa=3.0,
+    )
+
+    serial = []
+    for i in range(X_cand.shape[0]):
+        c = X_cand[i].reshape(1, -1)
+        mu, std = gp.predict(c, params=params, batch=batch, bounds=bounds)
+        serial.append(float(acquisitions.LCB(mu, std, kappa=3.0)[0]))
+
+    assert scores.shape == (N_CAND,)
+    onp.testing.assert_allclose(
+        onp.asarray(scores), onp.asarray(serial), rtol=1e-4, atol=1e-6
+    )
+
+
+def test_rejects_non_2d_candidates(gp1d):
+    gp, params, batch, bounds, X_cand = gp1d
+    with pytest.raises(ValueError, match=r"\(N, D\)"):
+        acquisitions.score_candidates(
+            gp, X_cand[0], params=params, batch=batch, bounds=bounds, best=0.0
+        )

--- a/tests/test_score_candidates.py
+++ b/tests/test_score_candidates.py
@@ -102,3 +102,30 @@ def test_rejects_non_2d_candidates(gp1d):
         acquisitions.score_candidates(
             gp, X_cand[0], params=params, batch=batch, bounds=bounds, best=0.0
         )
+
+
+def test_rejects_dim_mismatch(gp4d):
+    """(N, 1) candidates against a 4D model must fail loudly, not broadcast."""
+    gp, params, batch, bounds, _ = gp4d
+    X_wrong = jnp.linspace(0.0, 1.0, 8)[:, None]  # (8, 1) vs D=4
+    with pytest.raises(ValueError, match="D=4"):
+        acquisitions.score_candidates(
+            gp, X_wrong, params=params, batch=batch, bounds=bounds, best=0.0
+        )
+
+
+def test_rejects_per_candidate_acq_kwargs(gp1d):
+    """Per-candidate kwargs (LW_* weights) silently broadcast to (N, N) scores
+    in a naive vmap; score_candidates must reject them instead."""
+    gp, params, batch, bounds, X_cand = gp1d
+    weights = jnp.ones(X_cand.shape[0])  # one weight per candidate
+    with pytest.raises(ValueError, match="one score per candidate"):
+        acquisitions.score_candidates(
+            gp,
+            X_cand,
+            params=params,
+            batch=batch,
+            bounds=bounds,
+            acq_fn=acquisitions.LW_LCB,
+            weights=weights,
+        )


### PR DESCRIPTION
Closes #28

## What

`acquisitions.score_candidates(model, X_cand, *, params, batch, bounds, acq_fn=EI, **acq_kwargs)`: scores an (N, D) candidate array in one vmapped pass and returns (N,) scores. It replaces the consumer pattern in shelter-pulse (`jaxbo_optimizer.py`: per-candidate reshape to (1, 4), `gp.predict`, `acquisitions.EI`, host `float()`, over 256 candidates).

Contract, documented in the docstring:

- `X_cand` is RAW domain, normalized internally against `bounds`, exactly like `predict`; `batch` stays the ALREADY NORMALIZED training batch. Mixing them up fails silently, so the docstring says so.
- Each candidate is scored as a single (1, D) point, so `acq_fn` sees the module's single-point shapes (mean (1, 1), std (1,), the `[0]` convention). Any acquisition taking `(mean, std, **kwargs)` plugs in; extra kwargs (`best`, `kappa`) are forwarded and shared by all candidates.
- Lower is better; the next point is `X_cand[np.argmin(scores)]`. The Cholesky factor does not depend on the candidate, so vmap computes it once, not N times.
- Loud failures instead of silent broadcasting: a dimension mismatch ((N, 1) candidates against a 4D model) and per-candidate acq_kwargs (LW_* weights, which would silently produce N*N scores) both raise ValueError.

## Acceptance criteria

- [x] `score_candidates` vmap wrapper with shape-convention docstrings (single-point `[0]` convention and the raw-vs-normalized contract documented)
- [x] Unit test proves parity with the Python-loop result on EI (`tests/test_score_candidates.py`: verbatim serial consumer loop, 1D and 4D, same argmin; plus acq_fn/kwargs forwarding via LCB and three loud-failure guards)
- [x] Benchmark `bench_acquisition` gains a batched case showing the delta vs the loop (`bench_ei_score_candidates_256`, delta record committed at `benchmarks/results/2026-07-29-score-candidates.md`)

## Benchmark delta (AGENTS.md rule: no perf claim without numbers)

Before and after measured in the SAME environment and session on the final code: Python 3.12.6, jax/jaxlib 0.10.2, numpy 2.5.1, scipy 1.18.0, CPU only, Windows 10 build 19045. Medians of 3 `pytest benchmarks/bench_acquisition.py` runs (full record: `benchmarks/results/2026-07-29-score-candidates.md`):

| Case | Run 1 | Run 2 | Run 3 | Median | Per candidate |
|---|---|---|---|---|---|
| EI consumer path, 256 candidates (before) | 230.3 ms | 224.4 ms | 177.5 ms | 224.4 ms | 0.877 ms |
| EI fused `gp.acquisition` loop (reference) | 150.2 ms | 131.7 ms | 129.7 ms | 131.7 ms | 0.514 ms |
| `score_candidates`, 256 candidates (after) | 2.95 ms | 2.91 ms | 2.67 ms | 2.91 ms | 0.011 ms |

- Delta: 224.4 ms to 2.91 ms, a 77x speedup (98.7 percent reduction). The consumer-path noise band in `benchmarks/results/2026-07-28-baseline.md` is 9.9 percent; this clears it by two orders of magnitude.
- First-call latency (trace + compile + execute) of the batched case: 0.67 to 0.90 s, in line with the loop's first candidate (0.43 to 0.55 s), so nothing is smuggled into compile time.
- The 2026-07-28 baseline recorded the consumer path at 137.0 ms on jax 0.9.2; jax is now 0.10.2 (post #52) and these runs sat on a busier machine, which is why before AND after were re-measured together instead of comparing against the stored baseline number. The baseline file is a historical record and is not edited.

## Adversarial review

Codex adversarial review (vmap correctness vs serial loop, normalization contract, shape edge cases, dtype/device sync) ran pre-PR and returned 3 findings, all addressed:

1. (N, 1) candidates against a 4D model broadcast silently inside predict: now rejected with a ValueError naming the expected D, plus a regression test.
2. Per-candidate acq_kwargs (LW_* weights) made each mapped call return a vector, which the final reshape flattened to N*N scores silently: now rejected loudly, documented, with a regression test. Mapped kwargs (in_axes plumbing) are deliberately out of scope; use vmap directly for weighted acquisitions.
3. The perf claim lacked a committed delta artifact: `benchmarks/results/2026-07-29-score-candidates.md` added, table above re-measured on the final code.

## Verification

- `uvx tox -e py312`: green, 24 passed (re-run on the final code after the review fixes)
- `uvx tox -e lint` (black 25.1.0 + ruff 0.16.0, pinned): clean
- `pytest benchmarks --benchmark-disable`: 8 passed (suite smoke)
- Em/en dash scan and `clip(a_min=)` scan over changed files: clean

## Overlap notes for parallel slices

- 2b (mcmc/multifidelity extras) and 2d (model test coverage) own their own files; this PR touches only `jaxbo/acquisitions.py`, its new test file, `benchmarks/bench_acquisition.py` + README row, and a new results record. No shared files.
