### PR TITLE
docs: add community files: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, templates, CITATION.cff (4a)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: Something in jaxbo is broken or behaves unexpectedly
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: >-
+        The smallest script that shows the problem. Include the data shapes
+        and the seed if randomness is involved.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: Output of the command below.
+      placeholder: |
+        python -c "import sys, jax, jaxlib, numpy, scipy, jaxbo; print(sys.version); print('jax', jax.__version__, 'jaxlib', jaxlib.__version__); print('numpy', numpy.__version__, 'scipy', scipy.__version__)"
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: install
+    attributes:
+      label: How did you install jaxbo?
+      placeholder: pip install jaxbo / pip install jaxbo[all] / from source
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
       label: Versions
       description: Output of the command below.
       placeholder: |
-        python -c "import sys, jax, jaxlib, numpy, scipy, jaxbo; print(sys.version); print('jax', jax.__version__, 'jaxlib', jaxlib.__version__); print('numpy', numpy.__version__, 'scipy', scipy.__version__)"
+        python -c "import sys, jax, jaxlib, numpy, scipy, jaxbo; print(sys.version); print('jax', jax.__version__, 'jaxlib', jaxlib.__version__); print('numpy', numpy.__version__, 'scipy', scipy.__version__); print('jaxbo', jaxbo.__version__)"
       render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
       label: Versions
       description: Output of the command below.
       placeholder: |
-        python -c "import sys, jax, jaxlib, numpy, scipy, jaxbo; print(sys.version); print('jax', jax.__version__, 'jaxlib', jaxlib.__version__); print('numpy', numpy.__version__, 'scipy', scipy.__version__); print('jaxbo', jaxbo.__version__)"
+        python -c "import sys, importlib.metadata as md, jax, jaxlib, numpy, scipy; print(sys.version); print('jax', jax.__version__, 'jaxlib', jaxlib.__version__); print('numpy', numpy.__version__, 'scipy', scipy.__version__); print('jaxbo', md.version('jaxbo'))"
       render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/ricardogr07/JAX-BO/security/advisories/new
+    about: Report a vulnerability privately. Please do not use the public tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Propose an addition or change to jaxbo
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that jaxbo makes hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >-
+        What would the API look like? A sketch of the call you wish existed
+        is more useful than prose.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other designs you rejected.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## What
+
+<!-- One or two sentences: what changes and why. -->
+
+Closes #
+
+## Checklist
+
+- [ ] Conventional commit title (`fix:`, `feat:`, `docs:`, `refactor:`, `test:`, `ci:`); release-please cuts releases from it
+- [ ] `uv run pytest tests` green locally
+- [ ] `uvx tox -e lint` green (pinned black + ruff)
+- [ ] No em or en dashes anywhere (code, docs, this PR body); ranges written as "X to Y"
+- [ ] Perf claim? Before/after numbers from the `benchmarks/` suite are in the description (see CONTRIBUTING.md, the benchmark delta rule)
+- [ ] Removal or public signature change? The commit message carries the changelog line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Agent rules for JAX-BO
 
+Contributor rules (dev setup, tox, the CI gate map, PR rules, the benchmark
+delta rule, house style) live in **`CONTRIBUTING.md`**. Read it first; this
+file only carries what is specific to agent sessions.
+
 ## HARD RULE: fork only, never upstream
 
 NEVER create or modify ANYTHING on github.com/PredictiveIntelligenceLab/JAX-BO
@@ -13,12 +17,10 @@ Mechanics:
 - The `upstream` remote's push URL is set to DISABLED on purpose. Do not
   restore it. Fetch from upstream is allowed for divergence checks only.
 
-## House rules
+## Session rules
 
-- No em or en dashes anywhere: code, docs, commits, PR bodies. Use a colon or
-  comma; write ranges as "X to Y".
+- Workers open PRs on the fork; they do not merge.
 - No AI attribution ever: no Co-Authored-By trailers, no "Generated with"
   lines. Ricardo is the sole author.
-- Workers open PRs on the fork; they do not merge.
-- Optimization PRs must include a before/after benchmark delta from the
-  benchmarks suite; no perf change lands without numbers.
+- The no em/en dash rule and the benchmark delta rule live in
+  `CONTRIBUTING.md`; they bind agents exactly as they bind humans.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: >-
+  If you use this software, please cite this fork using the metadata below,
+  and please also cite the original JAX-BO library by the Predictive
+  Intelligence Lab (University of Pennsylvania), listed under references.
+title: "JAX-BO: a Bayesian optimization library in JAX (maintained fork)"
+type: software
+authors:
+  - family-names: "García Ramírez"
+    given-names: Ricardo
+    email: rgr.5882@gmail.com
+repository-code: "https://github.com/ricardogr07/JAX-BO"
+url: "https://github.com/ricardogr07/JAX-BO"
+license: Apache-2.0
+keywords:
+  - jax
+  - bayesian-optimization
+  - gaussian-processes
+  - machine-learning
+references:
+  - type: software
+    title: "JAX-BO: A Bayesian optimization library in JAX"
+    authors:
+      - family-names: Perdikaris
+        given-names: Paris
+      - family-names: Yang
+        given-names: Yibo
+      - family-names: Bhouri
+        given-names: "Mohamed Aziz"
+    year: 2020
+    version: "0.2"
+    repository-code: "https://github.com/PredictiveIntelligenceLab/JAX-BO"
+    institution:
+      name: "Predictive Intelligence Lab, University of Pennsylvania"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political
+  attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+rgr.5882@gmail.com. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of
+Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to JAX-BO
+
+Thanks for your interest in contributing. This document covers everything a
+contributor needs: where work happens, how to set up a dev environment, what
+CI runs against your change, and the rules a pull request must satisfy.
+
+## Where work happens: this fork only
+
+This repository is a maintained fork of
+[PredictiveIntelligenceLab/JAX-BO](https://github.com/PredictiveIntelligenceLab/JAX-BO).
+All development happens here, on `ricardogr07/JAX-BO`. Please do not open
+pull requests, issues, or comments on the upstream repository on behalf of
+this project; upstream is credited (see the README acknowledgment section and
+`CITATION.cff`) but is not contacted. Agent sessions have additional
+mechanics for this rule in `AGENTS.md`.
+
+## Dev setup
+
+The project uses [uv](https://docs.astral.sh/uv/) with a committed lockfile
+(`uv.lock`). Python 3.10 or newer is required.
+
+```bash
+git clone https://github.com/ricardogr07/JAX-BO.git
+cd JAX-BO
+uv sync          # creates .venv from uv.lock; installs the dev group
+uv run pytest tests
+```
+
+`uv sync` installs the `dev` dependency group, which includes pytest,
+pytest-cov, and the packages backing the optional extras (numpyro,
+scikit-learn, KDEpy) so the whole test suite, including the extras and their
+compatibility shims, runs locally.
+
+The package itself installs with exactly 4 runtime dependencies (`jax`,
+`jaxlib`, `numpy`, `scipy`); everything else lives behind the optional
+extras `[mcmc]`, `[multifidelity]`, `[weighted]`, and their union `[all]`.
+Keep it that way: no core module may import an extras dependency, even
+transitively. `tests/test_import_guards.py` enforces this.
+
+## Tox environments
+
+`tox.ini` defines the local multi-python runner plus the pinned lint env:
+
+| Env | What it runs |
+|---|---|
+| `py310` to `py314` | `pytest tests` against that interpreter, with `extras = all` |
+| `lint` | `black --check` and `ruff check` over `jaxbo/` and `tests/` |
+
+Run them with `uvx tox -e py312` or `uvx tox -e lint`. black and ruff are
+pinned in `tox.ini` on purpose (unpinned formatters broke CI twice); bump
+them deliberately, together with the `[tool.black]` and `[tool.ruff]`
+sections in `pyproject.toml`.
+
+## What CI runs against your change
+
+CI (`.github/workflows/ci.yml`) gates work by changed paths, so a docs-only
+PR does not pay for the full test matrix:
+
+| You changed | Jobs that run |
+|---|---|
+| Only `**/*.md` or `docs/**` | `lint` in docs scope (the markdown dash scan) |
+| `jaxbo/**`, `tests/**`, `pyproject.toml`, `tox.ini`, `uv.lock` | full `lint` + the `test` matrix |
+| `benchmarks/**` | `bench-smoke` (collection only, no timing) |
+| `.github/**` | everything |
+
+The `test` matrix is {py3.10, 3.11, 3.12, 3.13, 3.14} x {jax floor, jax
+latest} within the `jax>=0.6,<0.11` pin. The 3.13 and 3.14 lanes are
+advisory (`continue-on-error`) until they hold a green streak. CI installs
+frozen from `uv.lock`, then re-pins jax per lane. `ci-ok` aggregates all
+jobs and is the only required check; the release workflow refuses to publish
+unless `ci-ok` succeeded on the tagged commit.
+
+Full lint scope also runs two greps the codebase must stay clean under: no
+em or en dashes in markdown, and no `clip(a_min=, a_max=)` kwargs (removed
+in JAX 0.10; use positional `min, max`).
+
+## Pull request rules
+
+- Branch from `main`; open the PR against `main` on this fork.
+- **Conventional commit titles** (`fix:`, `feat:`, `docs:`, `refactor:`,
+  `test:`, `ci:`). Releases are cut by release-please from these prefixes,
+  so the title is load-bearing: a `feat:` bumps the minor version, a `fix:`
+  the patch version.
+- Reference the issue the PR closes: `Closes #<n>` in the body.
+- Green `ci-ok` before merge. Do not merge your own PR unless you are the
+  maintainer.
+- Every removal or public signature change gets a changelog line before
+  merge (release-please generates `CHANGELOG.md` from the commits, so say
+  it in the commit message).
+- Keep PRs sliced small; one concern per PR.
+
+### House style
+
+- No em or en dashes anywhere: code, docs, commits, PR bodies. Use a colon
+  or comma instead, and write ranges as "X to Y". CI enforces this for
+  markdown.
+- black + ruff clean (`uvx tox -e lint`), with the pinned versions.
+- Public functions and classes carry type hints and docstrings. This is a
+  review expectation, not a CI gate: the 70% docstring coverage figure
+  comes from the reposage audit the revamp is graded against (see
+  `docs/audits/`), which is re-run at release candidate time, not on every
+  PR.
+
+## The benchmark delta rule
+
+**No optimization lands without a before/after benchmark delta.** Any PR
+that claims a performance change must include numbers from the
+`benchmarks/` suite, produced on the same machine, same env, same seeds,
+before and after the change. If the delta is inside the per-bench noise
+band documented in the results file, the claim does not go in the PR
+description. A perf change without numbers is rejected regardless of how
+plausible it looks. See `benchmarks/README.md` for how to run the suite and
+how the rule is enforced.
+
+## Reporting bugs and requesting features
+
+Use the issue templates (they ask for the jaxbo/jax/python versions and a
+minimal repro). Security issues go through `SECURITY.md`, not the public
+tracker.
+
+## Code of conduct
+
+Participation in this project is covered by `CODE_OF_CONDUCT.md`
+(Contributor Covenant 2.1).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release line receives security fixes.
+
+| Version | Supported |
+|---|---|
+| latest release (see [PyPI](https://pypi.org/project/jaxbo/)) | yes |
+| older releases | no |
+
+## Reporting a vulnerability
+
+Please do not report security issues through the public issue tracker.
+
+Report privately instead, using either channel:
+
+- **GitHub private vulnerability reporting** (preferred):
+  [open a draft security advisory](https://github.com/ricardogr07/JAX-BO/security/advisories/new)
+- **Email:** rgr.5882@gmail.com with "jaxbo security" in the subject
+
+Include the affected version, a minimal reproduction, and the impact you
+see. You can expect an acknowledgment within 7 days. Once a fix is
+available it ships in a patch release and the advisory is published; you
+will be credited unless you prefer otherwise.
+
+## Scope notes
+
+jaxbo is a numerical library: it executes no network I/O and evaluates no
+untrusted code paths of its own. The most likely real-world issues are
+supply-chain ones (a compromised or vulnerable dependency) or unsafe
+deserialization of model parameters from untrusted sources. Reports in
+those areas are very welcome.


### PR DESCRIPTION
## What

Open source hardening slice 4a: the full community file set the repo was missing (only LICENSE existed).

- **CONTRIBUTING.md**: dev setup (uv + committed lockfile), the tox envs, the CI gate map (what runs per changed path), PR rules (conventional commits, Closes #n, green ci-ok), house style, and the benchmark delta rule. It absorbs the contributor-facing content that lived in AGENTS.md; AGENTS.md is now a thin pointer keeping only the agent-session mechanics (fork-only rule, no AI attribution, workers open PRs and do not merge).
- **CODE_OF_CONDUCT.md**: Contributor Covenant 2.1, enforcement contact set.
- **SECURITY.md**: private reporting via GitHub security advisories or email; supported-versions policy.
- **Issue templates** (bug report with version block, feature request, config with a security contact link) and a **PR template** carrying the house checklist.
- **CITATION.cff**: cites this fork and credits the original JAX-BO software by the Predictive Intelligence Lab (Perdikaris, Yang, Bhouri) as a reference entry. Validated with cffconvert (schema 1.2.0). Upstream is credited, never contacted.

Sibling PRs from the same slice set: the README rebuild (4b) links to these files; the Docker image (4g) is documented there.

## Verification

- cffconvert validate: green
- Issue template YAML parses
- Em/en dash scan over all changed files: clean
- Adversarial review run on the branch: 1 medium finding (CONTRIBUTING claimed a CI-enforced 70% docstring coverage gate that does not exist); fixed by rewording it as a review expectation tied to the reposage audit, which is what the 70% figure actually is.

Closes #33