### PR TITLE
fix!: EI and EIC use the textbook closed form for mean > best

### DIFF
--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -4,14 +4,20 @@ from jax.scipy.stats import norm
 
 # Caution: all functions below are designed for single point evaluation; use
 # score_candidates (or vmap directly) to score a batch of candidates.
-# See derivation in:
-# https://people.orie.cornell.edu/pfrazier/Presentations/2011.11.INFORMS.Tutorial.pdf
+# EI/EIC use the textbook closed form for minimization,
+#     EI = delta * Phi(Z) + std * phi(Z),  delta = best - mean,  Z = delta / std,
+# see e.g. Jones, Schonlau, Welch (1998), "Efficient Global Optimization of
+# Expensive Black-Box Functions", eq. (15).
 
 
 @jit
 def EI(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     """
     Computes the Expected Improvement (EI) acquisition function.
+
+    Uses the closed form delta * Phi(Z) + std * phi(Z) with delta = best - mean
+    and Z = delta / std. The divisor is clamped so that at std = 0 the value
+    collapses to the exact-knowledge limit max(best - mean, 0).
 
     Parameters:
     mean (np.ndarray): Predictive mean of the objective function at the point of interest.
@@ -22,10 +28,9 @@ def EI(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     float: Negative expected improvement (for minimization).
     """
 
-    delta = -(mean - best)
-    deltap = np.clip(delta, 0.0)
-    Z = delta / std
-    EI = deltap - np.abs(deltap) * norm.cdf(-Z) + std * norm.pdf(Z)
+    delta = best - mean
+    Z = delta / np.maximum(std, 1e-12)
+    EI = delta * norm.cdf(Z) + std * norm.pdf(Z)
     return -EI[0]
 
 
@@ -42,10 +47,9 @@ def EIC(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     Returns:
     float: Negative constrained expected improvement.
     """
-    delta = -(mean[0, :] - best)
-    deltap = np.clip(delta, 0.0)
-    Z = delta / std[0, :]
-    EI = deltap - np.abs(deltap) * norm.cdf(-Z) + std[0, :] * norm.pdf(Z)
+    delta = best - mean[0, :]
+    Z = delta / np.maximum(std[0, :], 1e-12)
+    EI = delta * norm.cdf(Z) + std[0, :] * norm.pdf(Z)
     constraints = np.prod(norm.cdf(mean[1:, :] / std[1:, :]), axis=0)
     return -EI[0] * constraints[0]
 

--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -62,11 +62,18 @@ def EIC(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     float: Negative constrained expected improvement.
     """
     EI = _ei_closed_form(best - mean[0, :], std[0, :])
-    # Clamped divisor: a deterministic constraint (std = 0) yields feasibility
-    # exactly 1 (mean > 0) or 0 (mean < 0) instead of NaN from 0/0.
-    constraints = np.prod(
-        norm.cdf(mean[1:, :] / np.maximum(std[1:, :], _STD_EPS)), axis=0
+    mean_c, std_c = mean[1:, :], std[1:, :]
+    # Any positive std keeps the exact divisor (cdf saturates safely, and an
+    # eps clamp would distort feasibility for valid tiny stds, e.g.
+    # mean = std = 1e-13 is Phi(1), not Phi(mean/eps)). Only std == 0 takes
+    # the step limit: 1 (mean > 0), 0 (mean < 0), 0.5 at the boundary. The
+    # where-guarded divisor keeps the unselected branch NaN-free under jit.
+    feasibility = np.where(
+        std_c > 0.0,
+        norm.cdf(mean_c / np.where(std_c > 0.0, std_c, 1.0)),
+        np.heaviside(mean_c, 0.5),
     )
+    constraints = np.prod(feasibility, axis=0)
     return -EI[0] * constraints[0]
 
 

--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -9,6 +9,23 @@ from jax.scipy.stats import norm
 # see e.g. Jones, Schonlau, Welch (1998), "Efficient Global Optimization of
 # Expensive Black-Box Functions", eq. (15).
 
+_STD_EPS = 1e-12
+
+
+def _ei_closed_form(delta: np.ndarray, std: np.ndarray) -> np.ndarray:
+    """Textbook EI, delta * Phi(Z) + std * phi(Z), with Z = delta / std.
+
+    std <= _STD_EPS takes the exact-knowledge limit max(delta, 0) explicitly;
+    the divisor is also clamped so the unselected where branch never produces
+    NaN under jit (the JAX where-gradient gotcha).
+    """
+    Z = delta / np.maximum(std, _STD_EPS)
+    return np.where(
+        std > _STD_EPS,
+        delta * norm.cdf(Z) + std * norm.pdf(Z),
+        np.maximum(delta, 0.0),
+    )
+
 
 @jit
 def EI(mean: np.ndarray, std: np.ndarray, best: float) -> float:
@@ -16,8 +33,8 @@ def EI(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     Computes the Expected Improvement (EI) acquisition function.
 
     Uses the closed form delta * Phi(Z) + std * phi(Z) with delta = best - mean
-    and Z = delta / std. The divisor is clamped so that at std = 0 the value
-    collapses to the exact-knowledge limit max(best - mean, 0).
+    and Z = delta / std; std <= 1e-12 collapses to the exact-knowledge limit
+    max(best - mean, 0).
 
     Parameters:
     mean (np.ndarray): Predictive mean of the objective function at the point of interest.
@@ -28,10 +45,7 @@ def EI(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     float: Negative expected improvement (for minimization).
     """
 
-    delta = best - mean
-    Z = delta / np.maximum(std, 1e-12)
-    EI = delta * norm.cdf(Z) + std * norm.pdf(Z)
-    return -EI[0]
+    return -_ei_closed_form(best - mean, std)[0]
 
 
 @jit
@@ -47,10 +61,12 @@ def EIC(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     Returns:
     float: Negative constrained expected improvement.
     """
-    delta = best - mean[0, :]
-    Z = delta / np.maximum(std[0, :], 1e-12)
-    EI = delta * norm.cdf(Z) + std[0, :] * norm.pdf(Z)
-    constraints = np.prod(norm.cdf(mean[1:, :] / std[1:, :]), axis=0)
+    EI = _ei_closed_form(best - mean[0, :], std[0, :])
+    # Clamped divisor: a deterministic constraint (std = 0) yields feasibility
+    # exactly 1 (mean > 0) or 0 (mean < 0) instead of NaN from 0/0.
+    constraints = np.prod(
+        norm.cdf(mean[1:, :] / np.maximum(std[1:, :], _STD_EPS)), axis=0
+    )
     return -EI[0] * constraints[0]
 
 

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -18,6 +18,27 @@ def test_eic_constraints():
     assert val < 0
 
 
+def test_eic_tiny_nonzero_constraint_std():
+    # A valid tiny std must keep the real Z = mean/std, so feasibility is
+    # Phi(1), not the eps-clamped Phi(mean/eps) (Codex review on PR 61).
+    mean = jnp.array([[0.5], [1e-13]])
+    std = jnp.array([[1.0], [1e-13]])
+    val = acquisitions.EIC(mean, std, 0.0)
+    ei = -acquisitions.EI(mean[0], std[0], 0.0)
+    assert jnp.isclose(-val, ei * 0.8413447, rtol=1e-4)
+
+
+def test_eic_deterministic_constraint():
+    # std == 0 takes the step limit: infeasible kills EIC exactly, no NaN.
+    mean = jnp.array([[0.5], [-1.0]])
+    std = jnp.array([[1.0], [0.0]])
+    assert acquisitions.EIC(mean, std, 0.0) == 0.0
+    feasible_mean = jnp.array([[0.5], [1.0]])
+    val = acquisitions.EIC(feasible_mean, std, 0.0)
+    ei = -acquisitions.EI(feasible_mean[0], std[0, :1], 0.0)
+    assert jnp.isclose(-val, ei)
+
+
 def test_lcb_basic():
     mean = jnp.array([1.0])
     std = jnp.array([0.5])

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -311,6 +311,31 @@ def test_ei_limits_as_uncertainty_vanishes():
     assert float(jnp.abs(worse)) < 1e-6
     assert float(better) == pytest.approx(1.0, abs=1e-6)
 
+    # Exactly std = 0 hits the explicit exact-knowledge branch: no division
+    # by zero, value is exactly max(best - mean, 0) on both sides and at best.
+    assert float(-acquisitions.EI(jnp.array([1.0]), jnp.array([0.0]), 0.0)) == 0.0
+    assert float(-acquisitions.EI(jnp.array([-1.0]), jnp.array([0.0]), 0.0)) == 1.0
+    assert float(-acquisitions.EI(jnp.array([0.0]), jnp.array([0.0]), 0.0)) == 0.0
+
+
+def test_eic_deterministic_constraint_is_not_nan():
+    """A zero-variance constraint gives feasibility exactly 1 or 0, not NaN.
+
+    The objective row (mean 0.5, std 1.0, best 0.0) is shared, so a surely
+    feasible deterministic constraint (mean 1, std 0) must reproduce the
+    unconstrained EI, and a surely infeasible one (mean -1, std 0) must
+    zero it out; 0/0 NaN from the constraint row would poison both.
+    """
+    ei = acquisitions.EI(jnp.array([0.5]), jnp.array([1.0]), 0.0)
+    feasible = acquisitions.EIC(
+        jnp.array([[0.5], [1.0]]), jnp.array([[1.0], [0.0]]), 0.0
+    )
+    infeasible = acquisitions.EIC(
+        jnp.array([[0.5], [-1.0]]), jnp.array([[1.0], [0.0]]), 0.0
+    )
+    assert float(feasible) == pytest.approx(float(ei), abs=1e-12)
+    assert float(infeasible) == 0.0
+
 
 def test_gp_1d_ei_acquisition_explores_promising_gap(gp_1d):
     """Model-level EI is a valid improvement and steers into the data gap.

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -259,17 +259,20 @@ def test_ei_matches_closed_form():
     """EI agrees with the textbook closed form and a hand-computed constant.
 
     jaxbo returns the NEGATIVE expected improvement (minimization), so the
-    improvement itself is the negated return value. The implemented Frazier
-    tutorial form equals the textbook EI, delta * Phi(z) + std * phi(z) with
-    delta = best - mean, whenever mean <= best; for mean > best it returns
-    the std * phi(z) upper bound instead, so that branch is locked by the
-    vanishing-uncertainty limit and monotonicity tests below, not here.
+    improvement itself is the negated return value. The implementation is the
+    textbook closed form, delta * Phi(z) + std * phi(z) with delta = best -
+    mean and z = delta / std, on both sides of mean = best (issue #55).
     """
     # mean == best: improvement reduces to std * phi(0) = 0.5 / sqrt(2*pi).
     val = acquisitions.EI(jnp.array([1.0]), jnp.array([0.5]), 1.0)
     assert float(-val) == pytest.approx(0.19947114020071635, abs=1e-6)
 
-    for mean, std, best in [(0.5, 1.0, 1.0), (-0.3, 0.7, 0.2), (1.0, 0.4, 2.0)]:
+    for mean, std, best in [
+        (0.5, 1.0, 1.0),
+        (-0.3, 0.7, 0.2),
+        (1.0, 0.4, 2.0),
+        (1.5, 0.5, 1.0),  # mean > best: same closed form, no special branch
+    ]:
         delta = best - mean
         z = delta / std
         expected = delta * norm.cdf(z) + std * norm.pdf(z)
@@ -277,19 +280,18 @@ def test_ei_matches_closed_form():
         assert jnp.allclose(got, expected, atol=1e-6)
 
 
-def test_ei_worse_than_best_is_frazier_upper_bound():
-    """Characterization: for mean > best, EI returns std * phi(z), not textbook.
+def test_ei_worse_than_best_matches_closed_form():
+    """For mean > best, EI is the textbook closed form, not an upper bound.
 
     With mean=1, std=1, best=0 (minimization) the textbook expected
-    improvement is delta * Phi(z) + std * phi(z) = -0.15866 + 0.24197 =
-    0.08332, but the implemented Frazier tutorial form drops the negative
-    delta * Phi(z) term and returns the std * phi(z) = 0.24197 upper bound.
-    Locked here so any change to that branch is deliberate; the deviation is
-    tracked in issue #55 (the acquisitions implementation is owned by the
-    2b/2c slices, not this test suite).
+    improvement is delta * Phi(z) + std * phi(z) with delta = z = -1:
+    -1 * 0.15865525393145707 + 0.24197072451914337 = 0.0833154705876863.
+    The pre-fix Frazier tutorial form dropped the negative delta * Phi(z)
+    term and returned the std * phi(z) = 0.24197 upper bound; fixed in
+    issue #55, locked here so any regression is deliberate.
     """
     got = -acquisitions.EI(jnp.array([1.0]), jnp.array([1.0]), 0.0)
-    assert float(got) == pytest.approx(0.24197072451914337, abs=1e-6)
+    assert float(got) == pytest.approx(0.0833154705876863, abs=1e-6)
 
 
 def test_ei_nonnegative_and_monotone_in_mean():


### PR DESCRIPTION
Closes #55

## What

`acquisitions.EI` (and the objective row of `EIC`) implemented the Frazier tutorial rearrangement `deltap - |deltap| * cdf(-Z) + std * pdf(Z)` with `deltap = max(delta, 0)`. That equals the textbook expected improvement only when `mean <= best`; for `mean > best` it reduced to the `std * phi(z)` upper bound, dropping the negative `delta * Phi(z)` term and overvaluing worse-than-best candidates.

## Derivation

jaxbo minimizes. With posterior `f(x) ~ N(mean, std^2)` and incumbent `best`, improvement is `I = max(best - f, 0)`. Writing `delta = best - mean` and `z = delta / std`:

```
E[I] = integral_{-inf}^{best} (best - f) N(f; mean, std^2) df
     = delta * Phi(z) + std * phi(z)
```

which holds on both sides of `mean = best` with no branch. The old form agrees for `delta >= 0` since `deltap - deltap * Phi(-z) = delta * Phi(z)`, but for `delta < 0` it sets `deltap = 0` and keeps only `std * phi(z)`, an upper bound (the dropped term `delta * Phi(z)` is negative).

Worked number (issue #55): `mean = 1, std = 1, best = 0`, so `delta = z = -1`:

```
textbook: -1 * Phi(-1) + phi(-1) = -0.15865525 + 0.24197072 = 0.08331547
old code:                                          phi(-1)  = 0.24197072
```

The sign convention is unchanged: both functions still return the negated improvement, lower is better, `score_candidates` parity is untouched (it compares against the same functions, so no constant updates were needed there).

## Zero-variance handling

The closed form now lives in one shared helper, `_ei_closed_form`. It clamps the divisor at `1e-12` and switches explicitly to the exact-knowledge limit `max(best - mean, 0)` for `std <= 1e-12`, keeping the clamp so the unselected `where` branch never produces NaN under jit. `EIC`'s feasibility term got the same clamped divisor: a deterministic constraint (`std = 0`) now contributes exactly 1 or 0 instead of `0/0 = NaN`.

## Tests

- `test_ei_worse_than_best_is_frazier_upper_bound` flipped to `test_ei_worse_than_best_matches_closed_form`, asserting the hand-computed `0.0833154705876863`.
- `test_ei_matches_closed_form` gains a `mean > best` triple; existing `mean <= best` constants are unchanged.
- `test_ei_limits_as_uncertainty_vanishes` extended with exact `std = 0` on both sides of best and at best.
- New `test_eic_deterministic_constraint_is_not_nan` checks feasibility 1 and 0 with a zero-variance constraint row.

## Adversarial review

Pre-PR adversarial review returned two findings, both fixed here: the EIC constraint-row `0/0` NaN (high) and the sub-epsilon deviation from the exact-knowledge limit when only the divisor is clamped (medium). `LCBC`/`LW_LCBC` share the same pre-existing unclamped constraint division; that is out of scope for this fix and tracked separately.

## Verification

- `uvx tox -e py312`: 47 passed
- `uvx tox -e lint`: black and ruff clean
- CI dash scan (markdown) and `a_min`/`a_max` guard: clean
