### PR TITLE
fix: LCBC and LW_LCBC use the shared NaN-free constraint feasibility

### DIFF
--- a/jaxbo/acquisitions.py
+++ b/jaxbo/acquisitions.py
@@ -12,6 +12,23 @@ from jax.scipy.stats import norm
 _STD_EPS = 1e-12
 
 
+def _constraint_feasibility(mean_c: np.ndarray, std_c: np.ndarray) -> np.ndarray:
+    """Product over constraint rows of P(constraint >= 0) = Phi(mean/std).
+
+    Any positive std keeps the exact divisor (cdf saturates safely, and an
+    eps clamp would distort feasibility for valid tiny stds, e.g.
+    mean = std = 1e-13 is Phi(1), not Phi(mean/eps)). Only std == 0 takes
+    the step limit: 1 (mean > 0), 0 (mean < 0), 0.5 at the boundary. The
+    where-guarded divisor keeps the unselected branch NaN-free under jit.
+    """
+    feasibility = np.where(
+        std_c > 0.0,
+        norm.cdf(mean_c / np.where(std_c > 0.0, std_c, 1.0)),
+        np.heaviside(mean_c, 0.5),
+    )
+    return np.prod(feasibility, axis=0)
+
+
 def _ei_closed_form(delta: np.ndarray, std: np.ndarray) -> np.ndarray:
     """Textbook EI, delta * Phi(Z) + std * phi(Z), with Z = delta / std.
 
@@ -62,18 +79,7 @@ def EIC(mean: np.ndarray, std: np.ndarray, best: float) -> float:
     float: Negative constrained expected improvement.
     """
     EI = _ei_closed_form(best - mean[0, :], std[0, :])
-    mean_c, std_c = mean[1:, :], std[1:, :]
-    # Any positive std keeps the exact divisor (cdf saturates safely, and an
-    # eps clamp would distort feasibility for valid tiny stds, e.g.
-    # mean = std = 1e-13 is Phi(1), not Phi(mean/eps)). Only std == 0 takes
-    # the step limit: 1 (mean > 0), 0 (mean < 0), 0.5 at the boundary. The
-    # where-guarded divisor keeps the unselected branch NaN-free under jit.
-    feasibility = np.where(
-        std_c > 0.0,
-        norm.cdf(mean_c / np.where(std_c > 0.0, std_c, 1.0)),
-        np.heaviside(mean_c, 0.5),
-    )
-    constraints = np.prod(feasibility, axis=0)
+    constraints = _constraint_feasibility(mean[1:, :], std[1:, :])
     return -EI[0] * constraints[0]
 
 
@@ -94,7 +100,7 @@ def LCBC(
     float: Constrained LCB acquisition value.
     """
     lcb = mean[0, :] - threshold - kappa * std[0, :]
-    constraints = np.prod(norm.cdf(mean[1:, :] / std[1:, :]), axis=0)
+    constraints = _constraint_feasibility(mean[1:, :], std[1:, :])
     return lcb[0] * constraints[0]
 
 
@@ -120,7 +126,7 @@ def LW_LCBC(
     float: Weighted constrained LCB acquisition value.
     """
     lcb = mean[0, :] - threshold - kappa * std[0, :] * weights
-    constraints = np.prod(norm.cdf(mean[1:, :] / std[1:, :]), axis=0)
+    constraints = _constraint_feasibility(mean[1:, :], std[1:, :])
     return lcb[0] * constraints[0]
 
 

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -39,6 +39,25 @@ def test_eic_deterministic_constraint():
     assert jnp.isclose(-val, ei)
 
 
+def test_lcbc_deterministic_constraint_no_nan():
+    # 0/0 at a zero-variance constraint row used to return NaN (issue 62).
+    # mean == 0 at std == 0 takes the Phi step limit 0.5.
+    mean = jnp.array([[1.0], [0.0]])
+    std = jnp.array([[0.5], [0.0]])
+    val = acquisitions.LCBC(mean, std, kappa=2.0, threshold=3.0)
+    lcb = 1.0 - 3.0 - 2.0 * 0.5
+    assert jnp.isclose(val, lcb * 0.5)
+
+
+def test_lw_lcbc_deterministic_constraint_no_nan():
+    # Deterministic infeasible constraint zeroes the score exactly, no NaN.
+    mean = jnp.array([[1.0], [-1.0]])
+    std = jnp.array([[0.5], [0.0]])
+    weights = jnp.array([1.0])
+    val = acquisitions.LW_LCBC(mean, std, weights, kappa=2.0, threshold=3.0)
+    assert val == 0.0
+
+
 def test_lcb_basic():
     mean = jnp.array([1.0])
     std = jnp.array([0.5])


### PR DESCRIPTION
## Summary

LCBC and LW_LCBC still computed norm.cdf(mean[1:, :] / std[1:, :]) with an unclamped divisor, so a zero-variance constraint row with mean 0 evaluated 0/0 and returned NaN (found in the #55 adversarial review).

The EIC feasibility logic from #61 is now a shared _constraint_feasibility helper used by EIC, LCBC, and LW_LCBC:

- any positive std keeps the exact divisor (cdf saturates safely; an eps clamp would distort feasibility for valid tiny stds)
- std == 0 takes the step limit via heaviside(mean, 0.5): 1 feasible, 0 infeasible, 0.5 at the boundary
- the where-guarded divisor keeps the unselected branch NaN-free under jit

## Tests

- LCBC: zero-variance constraint at the boundary (mean 0) returns lcb * 0.5, the Phi step limit, not NaN
- LW_LCBC: deterministic infeasible constraint zeroes the score exactly, no NaN
- Full suite: 51 passed locally

Closes #62