### PR TITLE
perf: key the GP jit cache on config, not instance identity (3a)

### DIFF
--- a/jaxbo/gp.py
+++ b/jaxbo/gp.py
@@ -432,13 +432,16 @@ class GP(GPmodel):
           internally against ``bounds``.
 
     Note:
-        Instances compare equal when built from an equivalent options dict
-        (same kernel, criterion, and ``input_prior`` object). The jitted
-        methods take ``self`` as a static argument, so jax keys its
-        compilation cache on this equality: a second ``GP(...)`` with the
-        same configuration reuses every compilation the first one paid for
-        instead of recompiling per instance. The key is captured at
-        construction; mutating ``options`` afterwards does not rekey.
+        Instances compare equal when their live configuration matches: same
+        concrete class, kernel function, ``criterion``, and ``input_prior``
+        object (priors compare by identity and are never hashed, so
+        unhashable priors keep working). The jitted methods take ``self``
+        as a static argument, so jax keys its compilation cache on this
+        equality: a second ``GP(...)`` with the same configuration reuses
+        every compilation the first one paid for instead of recompiling per
+        instance. The key is read live at every call, so rebinding
+        ``options["criterion"]`` after construction moves the instance to
+        its own fresh cache line instead of hitting a stale one.
     """
 
     def __init__(self, options: Dict[str, Any]):
@@ -449,26 +452,31 @@ class GP(GPmodel):
                 with keys such as 'kernel', 'input_prior', and 'criterion'.
         """
         super().__init__(options)
-        # The traced methods read only self.kernel (and, in the acquisition
-        # dispatch, options["criterion"]) from the instance; input_prior is
-        # kept in the key as a guard, compared by object identity. This must
-        # stay in sync with what the jitted methods read from self, or equal
-        # instances with divergent behavior would silently share compiled
-        # code.
-        self._jit_cache_key = (
+
+    def _jit_cache_key(self) -> Tuple[Any, ...]:
+        # Everything the traced methods read from the instance, resolved
+        # live at call time so post-construction rebinding rekeys instead
+        # of hitting a stale compiled cache line. This must stay in sync
+        # with what the jitted methods read from self, or equal instances
+        # with divergent behavior would silently share compiled code. The
+        # prior participates by identity and is never hashed: it enters no
+        # trace, and id() keeps unhashable priors usable. Cache entries
+        # hold their GP (and so its prior) alive, so a live id cannot be
+        # recycled into a false match.
+        return (
             type(self),
             self.kernel,
             self.options.get("criterion"),
-            self.input_prior,
+            None if self.input_prior is None else id(self.input_prior),
         )
 
     def __hash__(self) -> int:
-        return hash(self._jit_cache_key)
+        return hash(self._jit_cache_key())
 
     def __eq__(self, other: object) -> Any:
         if not isinstance(other, GP):
             return NotImplemented
-        return self._jit_cache_key == other._jit_cache_key
+        return self._jit_cache_key() == other._jit_cache_key()
 
     @partial(jit, static_argnums=(0,))
     def compute_cholesky(

--- a/jaxbo/gp.py
+++ b/jaxbo/gp.py
@@ -430,6 +430,15 @@ class GP(GPmodel):
           against the domain bounds, targets standardized).
         - ``predict`` takes RAW domain points ``X_star`` and normalizes them
           internally against ``bounds``.
+
+    Note:
+        Instances compare equal when built from an equivalent options dict
+        (same kernel, criterion, and ``input_prior`` object). The jitted
+        methods take ``self`` as a static argument, so jax keys its
+        compilation cache on this equality: a second ``GP(...)`` with the
+        same configuration reuses every compilation the first one paid for
+        instead of recompiling per instance. The key is captured at
+        construction; mutating ``options`` afterwards does not rekey.
     """
 
     def __init__(self, options: Dict[str, Any]):
@@ -440,6 +449,26 @@ class GP(GPmodel):
                 with keys such as 'kernel', 'input_prior', and 'criterion'.
         """
         super().__init__(options)
+        # The traced methods read only self.kernel (and, in the acquisition
+        # dispatch, options["criterion"]) from the instance; input_prior is
+        # kept in the key as a guard, compared by object identity. This must
+        # stay in sync with what the jitted methods read from self, or equal
+        # instances with divergent behavior would silently share compiled
+        # code.
+        self._jit_cache_key = (
+            type(self),
+            self.kernel,
+            self.options.get("criterion"),
+            self.input_prior,
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._jit_cache_key)
+
+    def __eq__(self, other: object) -> Any:
+        if not isinstance(other, GP):
+            return NotImplemented
+        return self._jit_cache_key == other._jit_cache_key
 
     @partial(jit, static_argnums=(0,))
     def compute_cholesky(

--- a/tests/test_jit_cache.py
+++ b/tests/test_jit_cache.py
@@ -1,0 +1,81 @@
+"""jit compilation-cache keying tests (3a, issue #30).
+
+The ``GP`` methods decorated with ``static_argnums=(0,)`` key jax's
+compilation cache on the instance. ``GP`` therefore defines config-based
+``__eq__`` and ``__hash__``: two instances built from an equivalent options
+dict are interchangeable static arguments, so a second ``GP(...)``
+construction hits the caches the first one populated instead of paying the
+per-instance recompilation the fresh-instance bench measures.
+
+Retracing is the compile proxy here: jax only compiles what it has traced,
+and tracing calls the kernel function at Python level, so a counting kernel
+wrapper observes cache misses without touching jax private APIs.
+"""
+
+from jax import random
+
+import jaxbo.gp as gp_module
+import jaxbo.kernels as kernels
+from jaxbo import initializers
+from jaxbo.gp import GP
+
+CONFIG = {"kernel": "RBF", "criterion": "EI", "input_prior": None}
+
+
+def _demo_problem(n=16, d=2, seed=0):
+    key_x, key_y, key_p = random.split(random.PRNGKey(seed), 3)
+    X = random.uniform(key_x, (n, d))
+    y = random.normal(key_y, (n, 1))
+    params = initializers.random_init_GP(key_p, d)
+    return {"X": X, "y": y}, params
+
+
+def test_same_config_instances_are_equal():
+    assert GP(dict(CONFIG)) == GP(dict(CONFIG))
+    assert hash(GP(dict(CONFIG))) == hash(GP(dict(CONFIG)))
+
+
+def test_config_differences_break_equality():
+    base = GP(dict(CONFIG))
+    assert base != GP({**CONFIG, "kernel": "Matern52"})
+    assert base != GP({**CONFIG, "criterion": "LCB"})
+    # input_prior compares by object identity: a different prior object is a
+    # different cache line even if it would behave identically.
+    assert base != GP({**CONFIG, "input_prior": object()})
+    assert base != "not a GP"
+
+
+def test_second_instance_pays_zero_retraces(monkeypatch):
+    calls = {"n": 0}
+
+    # Defined inside the test so its identity is unique per run: the cache
+    # lines this test exercises cannot collide with entries other tests
+    # already compiled against the real RBF.
+    def counting_rbf(x1, x2, params):
+        calls["n"] += 1
+        return kernels.RBF(x1, x2, params)
+
+    monkeypatch.setitem(gp_module.SUPPORTED_KERNELS, "RBF", counting_rbf)
+
+    batch, params = _demo_problem()
+    bounds = {"lb": batch["X"].min(0), "ub": batch["X"].max(0)}
+    predict_kwargs = {"params": params, "batch": batch, "bounds": bounds}
+
+    first = GP(dict(CONFIG))
+    first.likelihood(params, batch)
+    first.predict(batch["X"], **predict_kwargs)
+    assert calls["n"] > 0, "first instance must trace"
+
+    calls["n"] = 0
+    second = GP(dict(CONFIG))
+    second.likelihood(params, batch)
+    second.predict(batch["X"], **predict_kwargs)
+    assert calls["n"] == 0, "equal-config instance must hit the jit cache"
+
+    # Granularity sanity: a different criterion is a different cache key, so
+    # even likelihood (which never reads the criterion) retraces. That is
+    # the price of keying conservatively on the whole config.
+    calls["n"] = 0
+    third = GP({**CONFIG, "criterion": "LCB"})
+    third.likelihood(params, batch)
+    assert calls["n"] > 0

--- a/tests/test_jit_cache.py
+++ b/tests/test_jit_cache.py
@@ -45,6 +45,56 @@ def test_config_differences_break_equality():
     assert base != "not a GP"
 
 
+class _UnhashablePrior:
+    """Value-equality prior stand-in: eq without hash, like a mutable dataclass."""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __eq__(self, other):
+        return isinstance(other, _UnhashablePrior) and self.tag == other.tag
+
+    __hash__ = None
+
+
+def test_unhashable_prior_keeps_identity_semantics():
+    prior = _UnhashablePrior("p")
+    gp = GP({**CONFIG, "input_prior": prior})
+    hash(gp)  # the prior must never be hashed itself
+    assert gp == GP({**CONFIG, "input_prior": prior})
+    # Equal by value but a different object: identity semantics, distinct
+    # cache line.
+    assert gp != GP({**CONFIG, "input_prior": _UnhashablePrior("p")})
+    batch, params = _demo_problem()
+    gp.likelihood(params, batch)  # jit static-arg hashing must accept it
+
+
+def test_criterion_mutation_rekeys(monkeypatch):
+    calls = {"n": 0}
+
+    def counting_rbf(x1, x2, params):
+        calls["n"] += 1
+        return kernels.RBF(x1, x2, params)
+
+    monkeypatch.setitem(gp_module.SUPPORTED_KERNELS, "RBF", counting_rbf)
+
+    batch, params = _demo_problem()
+    warm = GP(dict(CONFIG))
+    warm.likelihood(params, batch)
+
+    # Mutating the criterion after construction must move the instance off
+    # the warmed cache line: the key is read live, so the mutated instance
+    # retraces instead of silently reusing code traced for the old config.
+    mutated = GP(dict(CONFIG))
+    assert mutated == warm
+    mutated.options["criterion"] = "LCB"
+    assert mutated != warm
+
+    calls["n"] = 0
+    mutated.likelihood(params, batch)
+    assert calls["n"] > 0
+
+
 def test_second_instance_pays_zero_retraces(monkeypatch):
     calls = {"n": 0}
 


### PR DESCRIPTION
Closes ricardogr07/JAX-BO#30

## What

The jitted GP methods take `self` as a static argument, so jax keyed its compilation cache on default object identity: every `GP()` construction recompiled every pjit from scratch, which is the ~350 ms fresh-vs-warm gap the v0.2.0 baseline measures at n=128 and what the consumer pays once per BO iteration.

`GP` now defines `__eq__`/`__hash__` over a config key captured at construction: `(type, kernel function, criterion, input_prior identity)`. Equal-config instances are interchangeable static arguments, so a second `GP()` hits every cache line the first one populated.

Scope: core `GP` only, per the issue. The extras subclass `GPmodel` directly and several carry extra traced state (nets, layer specs), so config equality is not safe to lift to the base class; they keep identity semantics.

## Measured: second GP() pays zero recompilation

`tests/test_jit_cache.py` proves it without jax private APIs: a counting kernel wrapper observes trace-time calls, and an equal-config second instance triggers zero retraces (tracing is a precondition of compilation). Config differences (kernel, criterion, prior identity) still retrace.

## Before/after benchmark delta (paired protocol from the 3z baseline)

Interleaved same-session pairs on a verified-quiet machine (main, branch, main, branch), medians in ms:

| Bench | before 1 | after 1 | before 2 | after 2 | delta 1 | delta 2 |
|---|---|---|---|---|---|---|
| train fresh instance, n=128 | 846.00 | 164.36 | 674.83 | 158.94 | **-80.6%** | **-76.4%** |
| train warm instance, n=32 | 68.76 | 75.33 | 72.47 | 65.77 | +9.6% | -9.2% |
| train warm instance, n=128 | 161.80 | 162.34 | 168.53 | 157.66 | +0.3% | -6.5% |
| train warm instance, n=512 | 2297.64 | 2075.79 | 1860.68 | 1778.60 | -9.7% | -4.4% |
| predict, 256 batched | 1.48 | 1.61 | 1.72 | 1.47 | +9.2% | -14.8% |
| EI consumer path, 256 | 177.91 | 176.65 | 184.01 | 188.86 | -0.7% | +2.6% |
| EI fused acquisition, 256 | 117.62 | 126.42 | 113.76 | 112.60 | +7.5% | -1.0% |
| EI score_candidates, 256 | 1.94 | 2.20 | 2.00 | 2.02 | +13.5% | +0.6% |

- The gated bench (fresh instance) clears its documented 60.4 percent noise band in both pairs, and its before/after IQRs are fully disjoint: before [800.3 .. 913.7] / [654.6 .. 802.0], after [162.1 .. 173.7] / [156.9 .. 168.5].
- The fresh-minus-warm recompile gap collapses from 684.2 / 506.3 ms to **2.0 / 1.3 ms** per pair: a fresh `GP()` now costs the same as re-training a warmed instance.
- Every other bench moves inside pair noise with mixed signs, consistent with no other code path changing.

## Checks

- `uv run pytest tests`: 54 passed (51 existing + 3 new)
- `uvx tox -e lint`: black and ruff clean