### PR TITLE
fix: authenticate release-please with a PAT so tags trigger release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,3 +24,8 @@ jobs:
         # Manifest mode: version policy lives in release-please-config.json
         # (bump-minor-pre-major keeps pre-1.0 breaking changes on 0.x).
         uses: googleapis/release-please-action@v4
+        with:
+          # A PAT, not the default GITHUB_TOKEN: GitHub suppresses workflow
+          # events from GITHUB_TOKEN, so the tag it pushes would never fire
+          # release.yml (issue #66).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,12 @@
 name: Publish Python distribution to PyPI
 
+# Tag push only. Once release-please authenticates with a PAT (issue #66) it
+# emits both a tag push and a release-created event; triggering on both would
+# start two concurrent runs racing on the :latest docker tag.
 on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [created]
   workflow_dispatch:
 
 


### PR DESCRIPTION
## What

`release-please-action` ran with the default `GITHUB_TOKEN`, whose events GitHub suppresses. The v0.2.0 tag it pushed never fired `release.yml`: PyPI needed a manual `workflow_dispatch` and `docker-publish` was skipped by its guard, so no GHCR image exists for that version. This passes a PAT via the `token:` input, and drops the now-redundant `release:` trigger.

Closes #66

## Requires a secret before merge

`RELEASE_PLEASE_TOKEN` must exist as a repository secret or release-please fails on the next run. Fine-grained PAT scoped to this repo, Contents: read and write, Pull requests: read and write.

## Why the release: trigger goes

With a working PAT, release-please emits both a tag push and a release-created event. Triggering on both would start two concurrent `release.yml` runs racing on the `:latest` docker tag. That trigger was itself a workaround for this same bug. The `docker-publish` guard is unchanged and still matches through its `(ref_type == 'tag' && event_name == 'push')` clause.

## Not covered here

The v0.2.0 GHCR image (acceptance criterion 3) is backfilled by a one-off local `docker build` and push of `:0.2.0`, leaving `:latest` untouched. Not a workflow change: re-firing `release.yml` on an old tag would overwrite `:latest`.

## Verification

Real test is the next release. Merge release PR #69, then confirm `release.yml` starts by itself with no manual dispatch, that both `build-and-publish` and `docker-publish` are green, and that exactly one run exists for `v0.2.1`.

## Checklist

- [x] Conventional commit title (`fix:`, `feat:`, `docs:`, `refactor:`, `test:`, `ci:`); release-please cuts releases from it
- [x] `uv run pytest tests` green locally (not applicable, CI config only, no Python touched)
- [x] `uvx tox -e lint` green (pinned black + ruff) (not applicable, no Python touched)
- [x] No em or en dashes anywhere (code, docs, this PR body); ranges written as "X to Y"
- [x] Perf claim? Before/after numbers from the `benchmarks/` suite are in the description (no perf claim)
- [x] Removal or public signature change? The commit message carries the changelog line (no public API change)
