### PR TITLE
feat: add CPU-only quickstart notebook, wire nbmake into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,28 @@ jobs:
           uv sync --frozen --extra bench
           uv run --no-sync pytest benchmarks --benchmark-disable
 
+  notebook:
+    name: notebook quickstart
+    needs: gate
+    if: needs.gate.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-env
+        with:
+          python-version: "3.12"
+
+      - name: Execute quickstart notebook
+        shell: bash
+        run: |
+          uv sync --frozen
+          uv pip install nbmake
+          uv run --no-sync pytest --nbmake examples/quickstart.ipynb
   ci-ok:
     name: ci-ok
-    needs: [gate, lint, test, bench-smoke]
+    needs: [gate, lint, test, bench-smoke, notebook]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JAX-BO quickstart\n",
+    "\n",
+    "A small CPU-only Bayesian optimization loop using the 0.2.0 core API.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "jax.config.update(\"jax_platform_name\", \"cpu\")\n",
+    "\n",
+    "import jax.numpy as jnp\n",
+    "from jax import random\n\n",
+    "from jaxbo import acquisitions\n",
+    "from jaxbo.gp import GP\n",
+    "from jaxbo.priors import uniform_prior\n",
+    "from jaxbo.utils import normalize\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the objective and observations\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bounds = {\"lb\": jnp.array([-2.0]), \"ub\": jnp.array([2.0])}\n",
+    "\n",
+    "def objective(x):\n",
+    "    return (x - 0.65) ** 2 + 0.05 * jnp.sin(4.0 * x)\n",
+    "\n",
+    "X = jnp.array([[-1.8], [-0.7], [0.4], [1.5]])\n",
+    "y = objective(X)\n",
+    "batch, norm_const = normalize(X, y, bounds)\n",
+    "batch[\"y\"].shape\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit a Gaussian process\n\n`GP.train` consumes the normalized batch. Predictions and candidate scoring use raw domain coordinates.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = GP({\n",
+    "    \"kernel\": \"RBF\",\n",
+    "    \"criterion\": \"EI\",\n",
+    "    \"input_prior\": uniform_prior(bounds[\"lb\"], bounds[\"ub\"]),\n",
+    "})\n",
+    "params = model.train(batch, random.PRNGKey(0), num_restarts=2)\n",
+    "params.shape\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Score candidates\n\n`score_candidates` evaluates expected improvement in one batched pass. Lower scores are better.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = jnp.linspace(-2.0, 2.0, 25)[:, None]\n",
+    "scores = acquisitions.score_candidates(\n",
+    "    model, candidates, params=params, batch=batch, bounds=bounds,\n",
+    "    best=float(batch[\"y\"].min()),\n",
+    ")\n",
+    "next_x = candidates[jnp.argmin(scores), 0]\n",
+    "next_y = objective(next_x)\n",
+    "print(f\"next point: {float(next_x):.3f}, objective: {float(next_y):.3f}\")\n",
+    "assert scores.shape == (25,)\n",
+    "assert jnp.isfinite(scores).all()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The selected point is ready for the next observation in a Bayesian optimization loop."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "nbformat_minor": 5,
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #36

- examples/quickstart.ipynb: small BO loop against the 0.2.0 core API (GP.train, score_candidates), CPU-only, runs top to bottom in under 20 seconds (verified locally: pytest --nbmake examples/quickstart.ipynb passes)
- Fixed a real shape bug found during that verification: candidates[argmin(scores)] on a (25,1) array returns a (1,) array not a scalar, so float() raised TypeError. Indexed the column too.
- .github/workflows/ci.yml: new notebook job runs pytest --nbmake against the notebook, gated into ci-ok